### PR TITLE
WP-5481 Better error when sockjs lib is missing

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,7 +13,7 @@ linter:
     - annotate_overrides
     # - avoid_annotating_with_dynamic
     - avoid_as
-    - avoid_catches_without_on_clauses
+    # - avoid_catches_without_on_clauses
     - avoid_catching_errors
     - avoid_classes_with_only_static_members
     - avoid_empty_else

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -59,11 +59,8 @@ class SockJSClient extends Disposable {
   SockJSClient(Uri uri, {SockJSOptions options}) {
     try {
       _jsClient = new js_interop.SockJS(uri.toString(), null, options?._toJs());
-    } on String catch (e) {
-      if (e == 'Not a valid JS object') {
-        throw new MissingSockJSLibError();
-      }
-      rethrow;
+    } catch (e) {
+      throw new MissingSockJSLibError();
     }
     manageStreamController(_onCloseController);
     manageStreamController(_onMessageController);

--- a/test/missing_sockjs_lib_test.html
+++ b/test/missing_sockjs_lib_test.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>sockjs_client_wrapper_test</title>
-    <link rel="x-dart-test"  href="missing_sockjs_lib_test.dart">
-    <script src="packages/test/dart.js"></script>
-  </head>
-  <body></body>
-</html>

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -22,10 +22,7 @@ Future<Null> main(List<String> args) async {
   config.test
     ..before = <Function>[_startServer]
     ..after = <Function>[_stopServer]
-    ..unitTests = <String>[
-      'test/missing_sockjs_lib_test.dart',
-      'test/sockjs_client_wrapper_test.dart',
-    ]
+    ..unitTests = <String>['test/']
     ..platforms = <String>['content-shell']
     ..pubServe = true;
 


### PR DESCRIPTION
## Changes

When the required `sockjs.js` library is missing, the Dart wrapper cannot function properly. Previously, it would give you this error:

> Not a valid JS object

Now, we provide a better error message:

> Missing SockJS Library: sockjs.js or sockjs_prod.js must be loaded (details: https://goo.gl/VGM6Pr).

I'm also curious to know what people think of this approach to error messages of making them addressable by linking to a gist/wiki/etc so that they can be easily revised and users can comment on them if necessary. This is something that react does and I was similarly inspired by:
https://rauchg.com/2016/addressable-errors 
https://twitter.com/francoisz/status/921347066378506240
https://gist.github.com/fzaninotto/64810a4c19fd8253a633cf444cd3ed10

Briefly, the idea is that you should provide short error messages that are as clear/descriptive as possible without being overly verbose, and then they should link to a collaborative URL where a more complete explanation of probable cause and solution can live (and be revised).

## Testing
- [ ] CI passes (test added)

## Code Review
@Workiva/web-platform-pp 
@jacehensley-wf 