### PR TITLE
Add version check to CI

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 0.0.0
+version: 1.0.1
 description: A Dart wrapper for the `sockjs-client` JS library.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>

--- a/smithy.yml
+++ b/smithy.yml
@@ -6,9 +6,10 @@ runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # 
 
 before_script:
   - dart --version
+  - pub get --packages-dir
 
 script:
-  - pub get --packages-dir
+  - ./tool/check_version.sh
   
 artifacts:
   dart-dependencies: # For RM dependency tracking

--- a/tool/check_version.sh
+++ b/tool/check_version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
+
+MASTER_REV=$(git rev-parse origin/master)
+CURRENT_REV=$(git rev-parse HEAD)
+
+TAG=$(git name-rev --tags --name-only $(git rev-parse HEAD))
+TAG="undefined"
+
+if [[ "$TAG" =~ $SEMVER_REGEX ]]; then
+  echo "Tagged Version, no pubspec.yaml version bump needed."
+  exit 0
+elif [ "$MASTER_REV" == "$CURRENT_REV" ]; then
+  echo "Untagged master, no pubspec.yaml version bump needed."
+  exit 0
+else
+  VERSION_DIFF=$(git log -L2,1:pubspec.yaml origin/master.. | grep +version:)
+  if [ -n "$VERSION_DIFF" ]; then
+    echo "Updated version: $VERSION_DIFF"; exit 0
+  else
+    echo "Didn't update version"; exit 1
+  fi
+fi


### PR DESCRIPTION
## Problem
We need a CI check that verifies that the `pubspec.yaml` version has been bumped since we release on every pull request.

## Changes
Add a `tool/check_version.sh` script and run it during CI. If the `pubspec.yaml` version is not changed, CI will fail.

## Testing
- [ ] Checkout 4352db1, run `./tool/check_version.sh`, verify that it fails
- [ ] Checkout e5c3769, run `./tool/check_version.sh`, verify that it passes
- [ ] CI passes

## Code Review
@Workiva/app-frameworks 