### PR TITLE
WP-5585 Disable logging; should be reactivated later behind debug flag

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -17,7 +17,6 @@ import 'dart:async';
 import 'dart:js';
 
 import 'package:js/js.dart';
-import 'package:logging/logging.dart';
 import 'package:w_common/disposable_browser.dart';
 
 import 'package:sockjs_client_wrapper/src/events.dart';
@@ -42,8 +41,6 @@ class MissingSockJSLibError extends Error {
 class SockJSClient extends Disposable {
   // The native SockJS client object.
   js_interop.SockJS _jsClient;
-
-  final _logger = new Logger('SockJSClient');
 
   // Event stream controllers.
   final StreamController<SockJSCloseEvent> _onCloseController =
@@ -116,20 +113,11 @@ class SockJSClient extends Disposable {
   ///
   /// Optionally, a [closeCode] and [reason] can be provided.
   void close([int closeCode, String reason]) {
-    _logger.fine([
-      'close()',
-      'code: $closeCode',
-      'reason: $reason',
-    ].join('\n\t'));
     _jsClient.close(closeCode, reason);
   }
 
   /// Send data to the server.
   void send(String data) {
-    _logger.fine([
-      'send()',
-      'data: $data',
-    ].join('\n\t'));
     _jsClient.send(data);
   }
 
@@ -157,12 +145,6 @@ class SockJSClient extends Disposable {
   }
 
   void _onClose(js_interop.SockJSCloseEvent event) {
-    _logger.fine([
-      'onClose event converted',
-      'code: ${event.code}',
-      'reason: ${event.reason}',
-      'wasClean: ${event.wasClean}',
-    ].join('\n\t'));
     _onCloseController.add(new SockJSCloseEvent(
         // ignore: avoid_as
         event.code,
@@ -173,20 +155,11 @@ class SockJSClient extends Disposable {
   }
 
   void _onMessage(js_interop.SockJSMessageEvent event) {
-    _logger.fine([
-      'onMessage event converted',
-      'data: ${event.data}',
-    ].join('\n\t'));
     // ignore: avoid_as
     _onMessageController.add(new SockJSMessageEvent(event.data));
   }
 
   void _onOpen(dynamic _) {
-    _logger.fine([
-      'onOpen event received',
-      'transport: ${_jsClient.transport}',
-      'url: ${Uri.parse(_jsClient.url)}',
-    ].join('\n\t'));
     _onOpenController.add(
         new SockJSOpenEvent(_jsClient.transport, Uri.parse(_jsClient.url)));
   }
@@ -205,18 +178,10 @@ class SockJSOptions {
   /// can be useful if you need to disable certain fallback transports.
   final List<String> transports;
 
-  final _logger = new Logger('SockJSOptions');
-
   /// Construct a [SockJSOptions] instance to be passed to the [SockJSClient]
   /// constructor.
   SockJSOptions({this.server, this.transports});
 
-  js_interop.SockJSOptions _toJs() {
-    _logger.fine([
-      'transforming for JS interop',
-      'server: $server',
-      'transports: $transports',
-    ].join('\n\t'));
-    return new js_interop.SockJSOptions(server: server, transports: transports);
-  }
+  js_interop.SockJSOptions _toJs() =>
+      new js_interop.SockJSOptions(server: server, transports: transports);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.0.1
+version: 1.0.2
 description: A Dart wrapper for the `sockjs-client` JS library.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>
@@ -11,7 +11,6 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  logging: ^0.11.3
   w_common: ^1.9.0
   
 dev_dependencies:


### PR DESCRIPTION
## Problem
Logging was too verbose by default.

## Solution
Remove logging for now. It can be re-added later behind a debug flag so that it's opt-in.

## Code Review
@Workiva/app-frameworks 