### PR TITLE
AF-1922 include cdn assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: dart
 
+# This is the last dev version prior to dart 2 being moved to the stable
+# version line.
 dart:
   - 1.24.3
-  - dev
+  - 2.0.0-dev.69.5
 
 # Workaround for issue with sandboxed Chrome in containerized Travis builds.
 sudo: required

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN echo "Starting the script section" && \
 		echo "script section completed"
 ARG BUILD_ARTIFACTS_DART-DEPENDENCIES=/build/pubspec.lock
 
+RUN tar -cvzf /build/assets.tar.gz -C lib sockjs.js sockjs_prod.js
+ARG BUILD_ARTIFACTS_CDN=/build/assets.tar.gz
+
 RUN mkdir /audit/
 ARG BUILD_ARTIFACTS_AUDIT=/audit/*
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.0.6
+version: 1.0.7
 description: A Dart wrapper for the `sockjs-client` JS library.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
## Issue
- The `js` files are static and it would be nice to reference them directly rather then through a packages path.

## Changes
**Source:**
- Publish the `sockjs.js` and `sockjs_prod.js` files.

**Tests:**
- n/a (tooling update)

## Areas of Regression
- n/a

## Testing
- verify assets are where they are expected to be (I pinned `.travis` to the version before due to the sdk causing conflicts, https://www.dartlang.org/dart-2#upper-constraints-on-the-sdk-version )

## Code Review
@Workiva/app-frameworks 