### PR TITLE
AF-2085 Minor dependency updates for Dart 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: dart
 # version line.
 dart:
   - 1.24.3
-  - 2.0.0-dev.69.5
+  - stable
 
 # Workaround for issue with sandboxed Chrome in containerized Travis builds.
 sudo: required

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,10 +18,10 @@ dev_dependencies:
   build_test: ">=0.9.0 <1.0.0"
   build_web_compilers: ">=0.2.0 <1.0.0"
   coverage: '>=0.10.0 <0.13.0'
-  dart_dev: ^1.9.5
+  dart_dev: ^2.0.0
   dart_style: ^1.0.8
   dependency_validator: ^1.2.1
-  test: ^0.12.30
+  test: ">=0.12.30 <2.0.0"
 
 transformers:
 - test/pub_serve:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.0.7
+version: 1.0.8
 description: A Dart wrapper for the `sockjs-client` JS library.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
# Problem
pub get could not solve with versions of dart_dev and test

# Changes
- Use newer dart_dev ^2.0.0
- Widen test version range to allow dart 1 & 2
- Run travis CI on dart 2 stable

# Testing
- [ ] CI passes under dart 1 & 2