### PR TITLE
Release sockjs_client_wrapper 1.0.11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.0.10
+version: 1.0.11
 description: A Dart wrapper for the `sockjs-client` JS library.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION


Requested by: @olesiathoms-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/sockjs_client_wrapper/compare/1.0.10...Workiva:release_sockjs_client_wrapper_1.0.11
Diff Between Last Tag and New Tag: https://github.com/Workiva/sockjs_client_wrapper/compare/1.0.10...1.0.11

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4523073540194304/logs/)