### PR TITLE
CPLAT-5271 Expose stream of heartbeat events received by client

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,6 +1,8 @@
 platforms:
 - chrome
 
+timeout: 5s
+
 presets:
   travis:
     reporter: expanded

--- a/example/main.dart
+++ b/example/main.dart
@@ -27,6 +27,10 @@ Future<Null> main() async {
     print('OPEN: ${event.transport} ${event.url}');
   });
 
+  socket.onHeartbeat.listen((event) {
+    print('HEARTBEAT');
+  });
+
   socket.onMessage.listen((event) {
     print('MSG: ${event.data}');
   });

--- a/example/server.js
+++ b/example/server.js
@@ -16,7 +16,7 @@ var http = require('http');
 var sockjs = require('sockjs');
 
 var options = {
-    heartbeat_delay: 5000,
+    heartbeat_delay: 1000,
     sockjs_url: 'https://cdn.jsdelivr.net/sockjs/1.1.4/sockjs.min.js',
 };
 var echo = sockjs.createServer(options);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -48,6 +48,8 @@ class SockJSClient extends Disposable {
   // Event stream controllers.
   final StreamController<SockJSCloseEvent> _onCloseController =
       StreamController<SockJSCloseEvent>.broadcast();
+  final StreamController<SockJSHeartbeatEvent> _onHeartbeatController =
+      StreamController<SockJSHeartbeatEvent>.broadcast();
   final StreamController<SockJSMessageEvent> _onMessageController =
       StreamController<SockJSMessageEvent>.broadcast();
   final StreamController<SockJSOpenEvent> _onOpenController =
@@ -78,10 +80,12 @@ class SockJSClient extends Disposable {
       throw MissingSockJSLibError();
     }
     manageStreamController(_onCloseController);
+    manageStreamController(_onHeartbeatController);
     manageStreamController(_onMessageController);
     manageStreamController(_onOpenController);
 
     _addManagedEventListenerToJSClient('close', _onClose);
+    _addManagedEventListenerToJSClient('heartbeat', _onHeartbeat);
     _addManagedEventListenerToJSClient('message', _onMessage);
     _addManagedEventListenerToJSClient('open', _onOpen);
 
@@ -98,6 +102,9 @@ class SockJSClient extends Disposable {
   ///
   /// The event will include the close code and reason, if available.
   Stream<SockJSCloseEvent> get onClose => _onCloseController.stream;
+
+  /// A stream of heartbeat events received from the server.
+  Stream<SockJSHeartbeatEvent> get onHeartbeat => _onHeartbeatController.stream;
 
   /// A stream of message events received from the server.
   ///
@@ -156,6 +163,10 @@ class SockJSClient extends Disposable {
         event.reason,
         // ignore: avoid_as
         wasClean: event.wasClean));
+  }
+
+  void _onHeartbeat(js_interop.SockJSHeartbeatEvent event) {
+    _onHeartbeatController.add(SockJSHeartbeatEvent());
   }
 
   void _onMessage(js_interop.SockJSMessageEvent event) {

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -35,6 +35,13 @@ class SockJSCloseEvent extends SockJSEvent {
   SockJSCloseEvent(this.code, this.reason, {this.wasClean}) : super._('close');
 }
 
+/// Event that represents a heartbeat received by a SockJS Client from the
+/// server.
+class SockJSHeartbeatEvent extends SockJSEvent {
+  /// Constructs a [SockJSHeartbeatEvent].
+  SockJSHeartbeatEvent() : super._('heartbeat');
+}
+
 /// Event that represents a message received by a SockJS Client from the server.
 class SockJSMessageEvent extends SockJSEvent {
   /// Message payload.

--- a/lib/src/js_interop.dart
+++ b/lib/src/js_interop.dart
@@ -69,6 +69,12 @@ class SockJSCloseEvent {
   external bool get wasClean;
 }
 
+/// Interface definition for the JS "heartbeat" event that is emitted from the
+/// SockJS client.
+@JS()
+@anonymous
+class SockJSHeartbeatEvent {}
+
 /// Interface definition for the JS "message" event that is emitted from the
 /// SockJS client.
 @JS()

--- a/test/sockjs_client_wrapper_test.dart
+++ b/test/sockjs_client_wrapper_test.dart
@@ -131,6 +131,17 @@ void _integrationSuite(
     expect(echos, equals(['message1', 'message2']));
   });
 
+  test('client receiving heartbeats from the server', () async {
+    client = createEchoClient();
+    await client.onOpen.first;
+    await client.onHeartbeat.take(2).toList();
+    client.close();
+  },
+      // Skip the heartbeat test when the transport is on an actual websocket,
+      // since websockets support a ping/pong protocol that our test node sockjs
+      // server uses instead of sending an `h` frame.
+      skip: expectedTransport == 'websocket');
+
   test('client closing the connection', () async {
     client = createEchoClient();
     await client.onOpen.first;

--- a/tool/server.js
+++ b/tool/server.js
@@ -15,7 +15,7 @@
 var http = require('http');
 var sockjs = require('sockjs');
 
-var echo = sockjs.createServer();
+var echo = sockjs.createServer({heartbeat_delay: 500});
 echo.on('connection', function(conn) {
     conn.on('data', function(message) {
         console.log('[echo] "' + message + '"');


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The SockJS client can receive heartbeat events from the SockJS server, but we don't currently expose that stream of events via the Dart wrapper and doing so may be useful.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Add an event stream (similar to the open/close/message ones that already exist) for heartbeat events received by the client.

## Testing
- [ ] CI passes (tests added)
