### PR TITLE
CPLAT-13152: More accurate detection of missing sockjs script

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -75,7 +75,11 @@ class SockJSClient extends Disposable {
       _jsClient = js_interop.SockJS(uri.toString(), null, options?._toJs());
       // ignore: avoid_catches_without_on_clauses
     } catch (e) {
-      throw MissingSockJSLibError();
+      if (!js_interop.hasSockJS) {
+        throw MissingSockJSLibError();
+      } else {
+        rethrow;
+      }
     }
     manageStreamController(_onCloseController);
     manageStreamController(_onMessageController);

--- a/lib/src/js_interop.dart
+++ b/lib/src/js_interop.dart
@@ -15,7 +15,12 @@
 @JS()
 library sockjs_client_wrapper.src.js_interop;
 
+import 'dart:js' show context;
+
 import 'package:js/js.dart';
+
+/// Returns true if SockJS is defined on the window.
+bool get hasSockJS => context['SockJS'] != null;
 
 /// Interface of the external `SockJS` object used for JS interop.
 @JS()

--- a/test/sockjs_client_wrapper_test.dart
+++ b/test/sockjs_client_wrapper_test.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 @TestOn('browser')
+@Timeout(Duration(seconds: 5))
 library sockjs_client.test.sockjs_client_test;
 
 import 'dart:async';
@@ -22,6 +23,7 @@ import 'package:test/test.dart';
 
 import 'package:sockjs_client_wrapper/src/client.dart';
 
+final _badUri = Uri.parse('http://localhost:9999');
 final _echoUri = Uri.parse('http://localhost:8000/echo');
 final _corUri = Uri.parse('http://localhost:8000/cor');
 final _fofUri = Uri.parse('http://localhost:8600/404');
@@ -74,6 +76,11 @@ void main() {
 
       _integrationSuite(
           'xhr-polling', createEchoClient, createCorClient, create404Client);
+    });
+
+    test('throws if connection fails', () async {
+      final client = SockJSClient(_badUri);
+      expect(client.onOpen.first, throwsA(isNot(isA<MissingSockJSLibError>())));
     });
 
     test('disposal should close the client', () async {

--- a/test/sockjs_client_wrapper_test.html
+++ b/test/sockjs_client_wrapper_test.html
@@ -18,6 +18,16 @@ limitations under the License.
 <html>
   <head>
     <title>sockjs_client_wrapper_test</title>
+    <script>
+      // Workaround to Chrome 86 DDC issues:
+      // https://github.com/dart-lang/sdk/issues/43193
+      if (typeof window.MemoryInfo == "undefined") {
+        if (typeof window.performance.memory != "undefined") {
+          window.MemoryInfo = function () {};
+          window.MemoryInfo.prototype = window.performance.memory.__proto__;
+        }
+      }
+    </script>
     <script src="packages/sockjs_client_wrapper/sockjs.js"></script>
     <link rel="x-dart-test"  href="sockjs_client_wrapper_test.dart">
     <script src="packages/test/dart.js"></script>


### PR DESCRIPTION
# [CPLAT-13152](https://jira.atl.workiva.net/browse/CPLAT-13152)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-13152)

@michaeldavis-wf reported that we currently throw an error indicating that the SockJS script is missing when in fact the connection failed because the connection failed.

This PR updates that logic to only throw that error when `window.SockJS` is also missing, otherwise we just rethrow the original error, which should allow the connection error to propagate.