### PR TITLE
Flutter 2 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.1.0
+version: 2.0.0
 description: A Dart wrapper for the `sockjs-client` JS library.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>
@@ -11,13 +11,20 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  w_common: ^1.20.1
+  w_common:
+    git:
+      url: git://github.com/zmeggyesi/w_common.git
+      ref: flutter-2-migration
+
+dependency_overrides:
+  logging: ^1.0.1
+  glob: ^2.0.1
 
 dev_dependencies:
   build_runner: ^1.7.1
-  build_test: ^0.10.9
+  build_test: any
   build_web_compilers: ^2.5.1
   dart_dev: ^3.0.0
-  dependency_validator: ^2.0.1
+#  dependency_validator: ^2.0.1
   test: ^1.9.1
   workiva_analysis_options: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,7 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  w_common:
-    git:
-      url: git://github.com/zmeggyesi/w_common.git
-      ref: flutter-2-migration
+  w_common: 1.20.4
 
 dependency_overrides:
   logging: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,17 +11,23 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  w_common: 1.20.4
+  w_common:
+    git:
+      url: https://github.com/zmeggyesi/w_common.git
+      ref: flutter-2-migration
 
 dependency_overrides:
   logging: ^1.0.1
   glob: ^2.0.1
+  args: ^2.0.0
+  watcher: ^1.0.0
+  package_config: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^1.7.1
+  build_runner: any
   build_test: any
-  build_web_compilers: ^2.5.1
-  dart_dev: ^3.0.0
+  build_web_compilers: any
+  dart_dev: ^3.6.4
 #  dependency_validator: ^2.0.1
   test: ^1.9.1
   workiva_analysis_options: ^1.1.0


### PR DESCRIPTION
## Motivation
Since Flutter 2 has been de facto mandated since its release (by Google upgrading all its core packages and requiring users to do so as well), `w_transport` should be upgraded to match. However, the nature of dependencies with other Workiva-internal packages is making this quite difficult to do form the outside, so I started to unravel the web of dependencies.

## Changes
Upgrade package dependencies to Flutter 2 compatibility

#### Release Notes
Upgrade package dependencies to Flutter 2 compatibility

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/sockjs_client_wrapper/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/sockjs_client_wrapper/blob/master/CONTRIBUTING.md#manual-testing-criteria

related Workiva/w_transport#345