### PR TITLE
Raise the Dart SDK minimum to at least 2.11.0

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -29,9 +29,6 @@ jobs:
         run: dart pub get
       - name: Validate dependencies
         run: dart run dependency_validator
-      - name: Check formatting
-        run: dart format --output=none --set-exit-if-changed .
-        if: ${{ matrix.sdk == 'stable' }}
       - name: Analyze project source
         run: dart analyze
       - name: Run tests
@@ -56,6 +53,8 @@ jobs:
         run: pub get
       - name: Validate dependencies
         run: pub run dependency_validator
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
       - name: Analyze project source
         run: dartanalyzer .
       - name: Run tests

--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [2.7.2]
+        sdk: [2.13.4]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.10.0
   build_test: '>=0.10.9 <2.0.0'
-  build_web_compilers: ^2.9.0
+  build_web_compilers: ^2.12.0
   dart_dev: ^3.6.5
   dependency_validator: ^2.0.1
   test: ^1.15.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Dart wrapper for the `sockjs-client` JS library.
 homepage: https://github.com/Workiva/sockjs_client_wrapper
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
   js: ^0.6.1


### PR DESCRIPTION
## Overview
This updates the minimum Dart version that can be used to at least 2.11.0. Why 2.11.0 and not 2.13.4? Because setting it to 2.12.0 or higher opts the project into null safety (https://dart.dev/null-safety) which our code has not been migrated to yet. 
## What about null safety?
Once a project has been migrated to null safety it is ok to update the  minimum to 2.12.0 or even 2.13.4 since everyone at Workiva should be  using 2.13.4 now.
## Review / Testing / QA / Merge
If CI passes please review and merge. Most Dart CI has already been updated to run under 2.13.4 already so updating the minimum here doesn't change any code, or CI circumstances.
If CI fails, it's likely because an image in the Dockerfile or skynet.yaml is still running an older version of Dart. It should be updated to one with Dart 2.13. A list of existing 2.13 images lives here  https://wiki.atl.workiva.net/display/CP/Dart+2.13+Upgrade Feel free to fix CI and get this PR merged. However if you don't get to it, be aware that Client Platform will be going through the batch to help fix  any failures.
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/up_dart_sdk_minimum_to_2.11`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/up_dart_sdk_minimum_to_2.11)