### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Dart dependencies
         run: pub get
       - name: Validate dependencies
-        run: pub run dependency_validator
+        run: dart run dependency_validator
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
       - name: Analyze project source


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)