### PR TITLE
Raise Max Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4
+
+- Dependency upgrades.
+
 ## 1.1.0
 
 - Update SockJS library to 1.5.0 and add sourcemaps.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   w_common: ^1.20.1
 
 dev_dependencies:
-  build_runner: ^1.10.0
+  build_runner: '>=1.10.0 <3.0.0'
   build_test: '>=0.10.9 <2.0.0'
   build_web_compilers: ^2.12.0
   dart_dev: ^3.6.5


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)