### PR TITLE
w_common v2 rollout - 2 of 2 raise min

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  w_common: '>=1.20.1 <3.0.0'
+  w_common: '^2.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.2


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This update will require w_common 2x by raising the min to ^2.0.0
All consumers have already been updated to allow w_common 2 in the
step 1 batch, so this PR should be a no-op.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v2_raise_min`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v2_raise_min)