### PR TITLE
w_common v3 rollout - 1 of 2 raise max

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  w_common: '^2.0.0'
+  w_common: '>=2.0.0 <4.0.0'
 
 dev_dependencies:
   build_runner: ^2.1.2


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!

This update will allow the nullsafe versions of w_common 3x 
by raising the max to < 4.0.0

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v3`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v3)