### PR TITLE
RM-152148 Release sockjs_client_wrapper 1.1.12

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.1.11
+version: 1.1.12
 description: A Dart wrapper for the `sockjs-client` JS library.
 homepage: https://github.com/Workiva/sockjs_client_wrapper
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [w_common v2 rollout - 2 of 2 raise min](https://github.com/Workiva/sockjs_client_wrapper/pull/47)
	* [FEA-1212 Update SockJS to v1.6.1](https://github.com/Workiva/sockjs_client_wrapper/pull/48)
	* [Prepare for dart_dev v4.0.0](https://github.com/Workiva/sockjs_client_wrapper/pull/51)
	* [Fix CI: Disable beta channel in CI since it's Dart 3.0](https://github.com/Workiva/sockjs_client_wrapper/pull/52)
	* [w_common v3 rollout - 1 of 2 raise max](https://github.com/Workiva/sockjs_client_wrapper/pull/53)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/sockjs_client_wrapper/compare/1.1.11...Workiva:release_sockjs_client_wrapper_1.1.12
Diff Between Last Tag and New Tag: https://github.com/Workiva/sockjs_client_wrapper/compare/1.1.11...1.1.12

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4523073540194304/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4523073540194304/?repo_name=Workiva%2Fsockjs_client_wrapper&pull_number=55)