### PR TITLE
Update dev dependencies for analyzer 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 dependencies:
   js: ^0.6.1
-  w_common: '>=2.0.0 <4.0.0'
+  w_common: ^3.0.0
 
 dev_dependencies:
   build_runner: ^2.1.2
   build_test: ^2.1.3
   build_web_compilers: ^3.0.0
-  dart_dev: '>=3.6.5 <5.0.0'
+  dart_dev: ^4.0.0
   dependency_validator: ^3.2.0
   test: ^1.15.7
   workiva_analysis_options: ^1.3.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! Now that we can resolve to analyzer 2
we can raise the minimums of many dependencies were ranged to support both 
analyzer 1 and 2.

```
  pubspec_codemod raise-min analyzer 2.0.0 --recursive
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  pubspec_codemod raise-min test_html_builder 3.0.0 --recursive
  pubspec_codemod raise-min dart_style 2.0.0 --recursive
  pubspec_codemod raise-min build_web_compilers 3.0.0 --recursive
  pubspec_codemod raise-min build_test 2.0.0 --recursive
  pubspec_codemod raise-min build_runner 2.0.0 --recursive
  pubspec_codemod raise-min w_common 3.0.0 --recursive
  pubspec_codemod raise-min w_common_tools 3.0.0 --recursive
  pubspec_codemod raise-min uuid 3.0.0 --recursive
  pubspec_codemod raise-min fluri 2.0.0 --recursive
  pubspec_codemod raise-min get_it 6.0.0 --recursive
  pubspec_codemod raise-min dart_dev 4.0.0 --recursive
```

A passing CI is sufficient QA (that means dependencies resolve and tests run and pass).

For question or concerns visit `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_dev_deps_analyzer2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_dev_deps_analyzer2)