### PR TITLE
Test Dart 2.18.7 base image created via GHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:0.0.0-dart2.18.7gha3
 WORKDIR /build/
 ADD . /build/
 


### PR DESCRIPTION
NO MERGE : Testing Dart 2.18.7 dart2_base_image GHA
---

This is a test PR to run CI with the base image created via github actions
instead of Workiva Build.

For more info, visit `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/test_dart_218_gha`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_dart_218_gha)