### PR TITLE
FEA-2863: Expose debug transport URL when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+
+- Add `debugUrl` field to `SockJSOpenEvent`, which will be set to the full
+SockJS URL connected to by the underlying transport when using the unminified
+`sockjs.js` asset.
+
 ## 1.2.0
 
 - Migrate to null safety. SDK constraint raised to 2.12

--- a/example/index.html
+++ b/example/index.html
@@ -20,7 +20,7 @@ limitations under the License.
     <title>SockJS Client (Dart)</title>
 </head>
 <body>
-    <script src="/packages/sockjs_client_wrapper/sockjs_prod.js"></script>
+    <script src="/packages/sockjs_client_wrapper/sockjs.js"></script>
     <script defer src="/main.dart.js"></script>
 </body>
 </html>

--- a/example/main.dart
+++ b/example/main.dart
@@ -18,13 +18,13 @@ import 'package:sockjs_client_wrapper/sockjs_client_wrapper.dart';
 
 Future<Null> main() async {
   print('Starting example');
-  final echoUri = Uri.parse('http://localhost:9999/echo');
+  final echoUri = Uri.parse('http://localhost:9009/echo');
   final options =
       SockJSOptions(transports: ['websocket', 'xhr-streaming', 'xhr-polling']);
   final socket = SockJSClient(echoUri, options: options);
 
   socket.onOpen.listen((event) {
-    print('OPEN: ${event.transport} ${event.url}');
+    print('OPEN: ${event.transport} ${event.url} ${event.debugUrl}');
   });
 
   socket.onMessage.listen((event) {

--- a/example/server.js
+++ b/example/server.js
@@ -29,4 +29,4 @@ echo.on('connection', function(conn) {
 
 var server = http.createServer();
 echo.installHandlers(server, {prefix:'/echo'});
-server.listen(9999, '0.0.0.0');
+server.listen(9009, '0.0.0.0');

--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -828,6 +828,7 @@ SockJS.prototype._connect = function() {
     transportObj.once('close', this._transportClose.bind(this));
     transportObj.transportName = Transport.transportName;
     this._transport = transportObj;
+    this.transportUrl = transportUrl;
 
     return;
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -165,8 +165,11 @@ class SockJSClient extends Disposable {
   }
 
   void _onOpen(_) {
-    _onOpenController
-        .add(SockJSOpenEvent(_jsClient.transport, Uri.parse(_jsClient.url)));
+    _onOpenController.add(SockJSOpenEvent(
+      _jsClient.transport,
+      Uri.parse(_jsClient.url),
+      Uri.parse(_jsClient.transportUrl ?? ''),
+    ));
   }
 }
 

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -48,6 +48,9 @@ class SockJSMessageEvent extends SockJSEvent {
 /// Event that represents the opening (successful connection) of a SockJS
 /// Client to the server.
 class SockJSOpenEvent extends SockJSEvent {
+  /// More specific URL used by the underlying transport. For debug use only.
+  final Uri debugUrl;
+
   /// The transport that was used to successfully connect to the server.
   ///
   /// E.g. "websocket" or "xhr-polling".
@@ -57,5 +60,5 @@ class SockJSOpenEvent extends SockJSEvent {
   final Uri url;
 
   /// Constructs a [SockJSOpenEvent].
-  SockJSOpenEvent(this.transport, this.url) : super._('open');
+  SockJSOpenEvent(this.transport, this.url, this.debugUrl) : super._('open');
 }

--- a/lib/src/js_interop.dart
+++ b/lib/src/js_interop.dart
@@ -41,6 +41,9 @@ class SockJS {
   /// E.g. "websocket" or "xhr-polling".
   external String get transport;
 
+  /// A more specific URL used by the underlying transport. For debug use only.
+  external String? get transportUrl;
+
   /// The URL of the server to which this client connected.
   external String get url;
 


### PR DESCRIPTION
## Motivation
For debugging purposes, it would be helpful to have access to the full URL used by the underlying SockJS transport (the one that includes the selected protocol and session ID). This is currently not exposed publicly anywhere.

## Changes
- Update the unminified `sockjs.js` file wrapped by this library to set `transportUrl` on the `SockJS` client instance.
- Update the `SockJSOpenEvent` Dart type to include a `debugUrl` field that gets set to the new `transportUrl` field