### PR TITLE
RM-222131 Release sockjs_client_wrapper 1.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.3.0
+version: 1.4.0
 description: A Dart wrapper for the `sockjs-client` JS library.
 homepage: https://github.com/Workiva/sockjs_client_wrapper
 


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [remove info request](https://github.com/Workiva/sockjs_client_wrapper/pull/70)
* Patch changes:
	* [FEA-2972: Dont publish internally](https://github.com/Workiva/sockjs_client_wrapper/pull/66)
	* [FEDX-695 : GHA OSS changes to sockjs_client_wrapper](https://github.com/Workiva/sockjs_client_wrapper/pull/67)
	* [Raise the build_web_compilers dependency max to v5.0.0](https://github.com/Workiva/sockjs_client_wrapper/pull/69)


Requested by: @blakeroberts-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/sockjs_client_wrapper/compare/1.3.0...Workiva:release_sockjs_client_wrapper_1.4.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/sockjs_client_wrapper/compare/1.3.0...1.4.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4523073540194304/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4523073540194304/?repo_name=Workiva%2Fsockjs_client_wrapper&pull_number=71)