### PR TITLE
Add otel instrumentation

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'dart:js';
+import 'dart:js_util' as js_util;
 
 import 'package:js/js.dart';
 import 'package:w_common/disposable_browser.dart';
@@ -116,6 +117,8 @@ class SockJSClient extends Disposable {
   ///
   /// The event will include the selected transport as well as the server URL.
   Stream<SockJSOpenEvent> get onOpen => _onOpenController.stream;
+
+  num get timeout => js_util.getProperty(_jsClient, '_timeout');
 
   /// Close this client.
   ///

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -18,6 +18,7 @@ import 'dart:js';
 import 'dart:js_util' as js_util;
 
 import 'package:js/js.dart';
+import 'package:opentelemetry/api.dart';
 import 'package:w_common/disposable_browser.dart';
 
 import 'package:sockjs_client_wrapper/src/events.dart';
@@ -54,6 +55,16 @@ class SockJSClient extends Disposable {
   final StreamController<SockJSOpenEvent> _onOpenController =
       StreamController<SockJSOpenEvent>.broadcast();
 
+  /// Context used to capture open and close events while establishing the
+  /// initial connection.
+  ///
+  /// This value is set to the current context during construction, then set to
+  /// root after the first open or close event. This is to correlate events
+  /// related to initial connection with the construction of this object without
+  /// creating long running traces due to events from much further along in the
+  /// sessions lifetime.
+  Context _context;
+
   /// Constructs a new [SockJSClient] that will attempt to connect to a SockJS
   /// server at the given [uri].
   ///
@@ -71,7 +82,7 @@ class SockJSClient extends Disposable {
   ///     final options = new SockJSOptions(
   ///         transports: ['websocket', 'xhr-streaming', 'xhr-polling']);
   ///     final client = new SockJSClient(uri, options: options);
-  SockJSClient(Uri uri, {SockJSOptions? options}) {
+  SockJSClient(Uri uri, {SockJSOptions? options}) : _context = Context.current {
     try {
       _jsClient = js_interop.SockJS(uri.toString(), null, options?._toJs());
       // ignore: avoid_catches_without_on_clauses
@@ -156,6 +167,13 @@ class SockJSClient extends Disposable {
   }
 
   void _onClose(js_interop.SockJSCloseEvent event) {
+    spanFromContext(_context).addEvent('sockjs.close', attributes: [
+      Attribute.fromString('sockjs.transport', _jsClient.transport),
+      Attribute.fromDouble('sockjs.timeout', timeout.toDouble()),
+      Attribute.fromInt('sockjs.close.code', event.code),
+      Attribute.fromString('sockjs.close.reason', event.reason),
+    ]);
+    _context = Context.root; // Reset context to root for future events.
     _onCloseController.add(SockJSCloseEvent(
       event.code,
       event.reason,
@@ -168,6 +186,11 @@ class SockJSClient extends Disposable {
   }
 
   void _onOpen(_) {
+    spanFromContext(_context).addEvent('sockjs.open', attributes: [
+      Attribute.fromString('sockjs.transport', _jsClient.transport),
+      Attribute.fromDouble('sockjs.timeout', timeout.toDouble()),
+    ]);
+    _context = Context.root; // Reset context to root for future events.
     _onOpenController.add(SockJSOpenEvent(
       _jsClient.transport,
       Uri.parse(_jsClient.url),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   js: ^0.6.1
   w_common: '>=2.0.0 <4.0.0'
+  opentelemetry: ^0.18.10
 
 dev_dependencies:
   build_runner: ^2.1.2

--- a/test/sockjs_client_wrapper_test.dart
+++ b/test/sockjs_client_wrapper_test.dart
@@ -96,6 +96,12 @@ void main() {
       client.close();
       await Future.wait([client.onClose.first, client.didDispose]);
     });
+
+    test('timeout option should set a timeout', () async {
+      final options = SockJSOptions(timeout: 1000);
+      final client = SockJSClient(_echoUri, options: options)..close();
+      expect(client.timeout, equals(1000));
+    });
   });
 }
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

During failure scenarios of establishing a websocket connection in deployed environments, it is difficult to understand the cause and effect of the failure. Likewise, it's difficult to understand the current health/distribution of transport types that SockJS uses. 

## Changes
  <!-- What this PR changes to fix the problem. -->

OpenTelemetry instrumentation was added to capture the open and close events of SockJS as OpenTelemetry span events.

Additionally, a unit test for the recently added timeout option was added.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/sockjs_client_wrapper/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/sockjs_client_wrapper/blob/master/CONTRIBUTING.md#manual-testing-criteria
