### PR TITLE
RM-332820 Release sockjs_client_wrapper 1.5.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sockjs_client_wrapper
-version: 1.4.1
+version: 1.5.0
 description: A Dart wrapper for the `sockjs-client` JS library.
 homepage: https://github.com/Workiva/sockjs_client_wrapper
 


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [add timeout option](https://github.com/Workiva/sockjs_client_wrapper/pull/73)
* Patch changes:
	* [Raise the w_common dependency max to v5.0.0](https://github.com/Workiva/sockjs_client_wrapper/pull/77)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/sockjs_client_wrapper/compare/1.4.1...Workiva:release_sockjs_client_wrapper_1.5.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/sockjs_client_wrapper/compare/1.4.1...1.5.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4523073540194304/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4523073540194304/?repo_name=Workiva%2Fsockjs_client_wrapper&pull_number=78)