### PR TITLE
chore(dependabot): add 4-day cooldown, exempt Docker from cooldown -- Review and Merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 4
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Dependabot 4-day cooldown rollout

This PR is part of an org-wide rollout of a 4-day Dependabot cooldown (JFrog Curation compatibility -- see linked policy). Docker/OS-image ecosystems (`docker`, `docker-compose`, `devcontainers`) are exempted from cooldown entirely (`exclude: ["*"]`) since they don't route through Artifactory/Curation. `github-actions` entries are left hands-off per policy (no cooldown added if none existed; existing cooldown left untouched if present).

**No `.github/dependabot.yml`/`.yaml` existed in this repo before this PR.** A new minimal `.github/dependabot.yml` was bootstrapped based on detected ecosystems: `github-actions,npm`.

Every non-OS-image, non-github-actions entry either got a new `cooldown.default-days: 4` block, or (if it already had `default-days >= 4`) was left untouched -- nothing was silently lowered.

### Diff

```diff
diff --git a/.github/dependabot.yml b/.github/dependabot.yml
new file mode 100644
index 0000000..c42c6e1
--- /dev/null
+++ b/.github/dependabot.yml
@@ -0,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 4
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
```

This PR was opened by an automated org-wide rollout; please review and merge.